### PR TITLE
fix(pipe_close): outpipe[1] was closed twice

### DIFF
--- a/src/exec/exec.c
+++ b/src/exec/exec.c
@@ -424,10 +424,6 @@ void	exec_cmd(t_node *node, t_env **env_list)
 					wrap_close(node->inpipe[1]);
 					wrap_close(node->inpipe[0]);
 				}
-				if (node->outpipe[1] != INT_MAX)
-				{
-					wrap_close(node->outpipe[1]);
-				}
 			}
 		}
 		reset_redirect(node->redirect);


### PR DESCRIPTION
issue: #78

### 変更内容
<!-- このプルリクエストで何が変更されるのかを簡潔に説明してください -->
pipeのfdを２回closeしていたので、一回減らした。
### 背景・目的
<!-- この変更がなぜ必要か、どのような問題があるのか、解決することでどのような利益があるのかを説明してください -->
builtinではないコマンドをpipeでつなぐとclose: Bad file descriptorが出る。
### 関連issue
<!-- 関連するissueがあれば、番号を使ってリンクしてください (例: fixes #123) -->
fixes #78 
### 変更方法
<!-- どのように変更を行ったのか、技術的な詳細があれば記載してください -->

### テスト方法
<!-- この変更に関連するテスト方法や確認方法を説明してください -->

### 追加情報
<!-- その他、このプルリクエストに関連する情報があれば記載してください -->

