### PR TITLE
fix: Incorrect return value when there is a redirect character

### DIFF
--- a/src/redirect/open_file.c
+++ b/src/redirect/open_file.c
@@ -21,11 +21,13 @@ int	open_redir_out(char *filename)
 	int	fd;
 
 	fd = 0;
-	fd = open (filename, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+	fd = open(filename, O_CREAT | O_WRONLY | O_TRUNC, 0644);
 	if (fd == -1)
 	{
+		write(STDERR_FILENO, PROMPT_ERROR, strlen(PROMPT_ERROR));
 		perror(filename);
 		g_return_error.redirect_error = true;
+		g_return_error.return_value = 1;
 	}
 	return (fd);
 }
@@ -38,8 +40,10 @@ int	open_redir_append(char *filename)
 	fd = open (filename, O_CREAT | O_WRONLY | O_APPEND, 0644);
 	if (fd == -1)
 	{
+		write(STDERR_FILENO, PROMPT_ERROR, strlen(PROMPT_ERROR));
 		perror(filename);
 		g_return_error.redirect_error = true;
+		g_return_error.return_value = 1;
 	}
 	return (fd);
 }
@@ -52,8 +56,10 @@ int	open_redir_in(char *filename)
 	fd = open (filename, O_RDONLY);
 	if (fd == -1)
 	{
+		write(STDERR_FILENO, PROMPT_ERROR, strlen(PROMPT_ERROR));
 		perror(filename);
 		g_return_error.redirect_error = true;
+		g_return_error.return_value = 1;
 	}
 	return (fd);
 }


### PR DESCRIPTION
fixes #105

### 変更内容
<!-- このプルリクエストで何が変更されるのかを簡潔に説明してください -->
リダイレクトをしたときに、openが失敗した際に返り値がおかしかったのを直しました。

### 背景・目的
<!-- この変更がなぜ必要か、どのような問題があるのか、解決することでどのような利益があるのかを説明してください -->

### 関連issue
<!-- 関連するissueがあれば、番号を使ってリンクしてください (例: fixes #123) -->

### 変更方法
<!-- どのように変更を行ったのか、技術的な詳細があれば記載してください -->
cat < /dddd

### テスト方法
<!-- この変更に関連するテスト方法や確認方法を説明してください -->

### 追加情報
<!-- その他、このプルリクエストに関連する情報があれば記載してください -->

